### PR TITLE
disable sending 'all white space' messages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -99,7 +99,7 @@ function ChatRoom() {
 
       <input value={formValue} onChange={(e) => setFormValue(e.target.value)} placeholder="say something nice" />
 
-      <button type="submit" disabled={!formValue}>🕊️</button>
+      <button type="submit" disabled={!formValue || formValue.replace(/^\s+/, '').replace(/\s+$/, '') === ''}>🕊️</button>
 
     </form>
   </>)


### PR DESCRIPTION
Chat currently does not check whether the message is 'all white space' text. This small addition should fix it.
However, I am currently unable to test if this will work, so it can be a wrong fix.

P. S. By the way, I am experienced neither in making pull requests nor in React 😅. Hopefully, it will not cause any problems.