### PR TITLE
Use limitToLast instead of limit in the query

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -63,7 +63,7 @@ function SignOut() {
 function ChatRoom() {
   const dummy = useRef();
   const messagesRef = firestore.collection('messages');
-  const query = messagesRef.orderBy('createdAt').limit(25);
+  const query = messagesRef.orderBy('createdAt').limitToLast(25);
 
   const [messages] = useCollectionData(query, { idField: 'id' });
 


### PR DESCRIPTION
Prevent awkwardness when the db will have more than 25 documents. Getting the last N documents while maintaining ASC order.